### PR TITLE
Bump torch from 1.13.0 to 2.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+packaging==23.1
 torch==2.0.0
 openai==0.27.0
 jinja2==3.1.2


### PR DESCRIPTION
Fixing [dependabot critical alert](https://github.com/microsoft/deep-language-networks/security/dependabot/1).