### PR TITLE
Allows loading templates from custom directory

### DIFF
--- a/dln/operator.py
+++ b/dln/operator.py
@@ -24,6 +24,7 @@ class GPT:
         "text-babbage-001",
         "text-ada-001",
         "gpt-3.5-turbo",
+        "gpt-35-turbo",
         "gpt-4",
         "gpt-4-32k",
     ]
@@ -226,7 +227,7 @@ class GPT:
         generation_options = self.generation_options.copy()
         generation_options.update(**kwargs)
 
-        if self.engine in ("gpt-3.5-turbo", "gpt-4", "gpt-4-32k"):
+        if self.engine in ("gpt-3.5-turbo", "gpt-35-turbo", "gpt-4", "gpt-4-32k"):
             if "return_logprobs" in generation_options:
                 del generation_options["return_logprobs"]
 

--- a/dln/template.py
+++ b/dln/template.py
@@ -25,7 +25,6 @@ class DLNTemplate:
 
 
 class Templates:
-    _instance = None
 
     def __init__(self, template_directory=None):
         if template_directory is None:
@@ -55,10 +54,7 @@ class Templates:
         if not version:
             version = "latest"
 
-        if Templates._instance is None:
-            Templates._instance = Templates(template_directory)
-
-        templates = Templates._instance._data[template_name]
+        templates = Templates(template_directory)._data[template_name]
 
         if version == "latest":
             template = max(templates, key=lambda x: x.version)

--- a/dln/template.py
+++ b/dln/template.py
@@ -27,9 +27,10 @@ class DLNTemplate:
 class Templates:
     _instance = None
 
-    def __init__(self):
+    def __init__(self, template_directory=None):
+        if template_directory is None:
+            template_directory = os.path.join(os.path.dirname(__file__), 'templates/')
         self._data = {}
-        template_directory = os.path.join(os.path.dirname(__file__), 'templates/')
         for filename in glob.glob(f"{template_directory}/*.yaml"):
             template_name = os.path.basename(filename).split(".")[0]
             template = yaml.safe_load(open(filename, "r"))
@@ -49,13 +50,13 @@ class Templates:
                 self._data[template_name].append(DLNTemplate(**ttemplate))
 
     @staticmethod
-    def get(template_name):
+    def get(template_name, template_directory=None):
         template_name, _, version = template_name.partition(":")
         if not version:
             version = "latest"
 
         if Templates._instance is None:
-            Templates._instance = Templates()
+            Templates._instance = Templates(template_directory)
 
         templates = Templates._instance._data[template_name]
 
@@ -70,5 +71,5 @@ class Templates:
         return template
 
 
-def load_template(template_name):
-    return Templates.get(template_name)
+def load_template(template_name, template_directory=None):
+    return Templates.get(template_name, template_directory)

--- a/tests/test_dln_templates.py
+++ b/tests/test_dln_templates.py
@@ -1,4 +1,5 @@
 import pytest
+import yaml
 
 from dln.template import DLNTemplate, Templates, load_template
 
@@ -29,3 +30,15 @@ def test_load_template():
     template = load_template("suffix_forward")
     rendered = template.render(input="input test", prompt="prompt test")
     assert rendered == ("""input test\n\nprompt test""")
+
+
+def test_custom_template_directory(tmp_path):
+    custom_template_dir = tmp_path / "templates"
+    custom_template_dir.mkdir()
+    template_file = custom_template_dir / "custom_template.yaml"
+    template_content = {"v1.0": {"template": "Custom template: {{ message }}"}}
+    with open(template_file, "w") as f:
+        f.write(yaml.dump(template_content))
+    template = load_template("custom_template", template_directory=custom_template_dir)
+    rendered = template.render(message="my message!")
+    assert rendered == "Custom template: my message!"


### PR DESCRIPTION
Allows specifying a custom directory from where templates are loaded. Otherwise, users are limited to the templates specified by DLN.

It also includes 'gpt-35-turbo' to available models for azure compatibility.