### PR TITLE
fix result log writer

### DIFF
--- a/dln/vi/utils.py
+++ b/dln/vi/utils.py
@@ -74,7 +74,7 @@ class ResultLogWriter(object):
         Returns:
             A ResultLogWriter object
         """
-        self.name = name if name is not None else dataset
+        self.name = name if name is not None else dataset.dataset_name
         self.path = path
         self.result_dict = {}
         self.result_dict[self.name] = {'training': [], 'examples': []}


### PR DESCRIPTION
- Fix ref to dataset name
- Store result log within the logs folder by default.
- Concat paths using os.path.join.