### PR TITLE
Gsm8k and dataset refac

### DIFF
--- a/dln/dataset.py
+++ b/dln/dataset.py
@@ -42,16 +42,6 @@ def option_shuffle(data_point, rng):
     return new_data_point
 
 
-# accessed outside dataset
-# get_size
-# reset_pointer
-# iterate
-# get_data
-# get_batch
-# instruction
-# output_classes
-
-
 class Dataset:
     def __init__(
         self,

--- a/dln/dataset.py
+++ b/dln/dataset.py
@@ -46,12 +46,12 @@ def option_shuffle(data_point, rng):
 # get_size
 # reset_pointer
 # iterate
-# prefix   ????
 # get_data
 # get_batch
 # name
 # instruction
 # output_classes
+
 
 class Dataset:
     def __init__(
@@ -400,8 +400,8 @@ class BBH(Dataset):
                 self.dataset["test"]["label"].append(target)
 
         # TODO: use a parameter instead
-        val_examples = {"hyperbaton": 300}.get(self.dataset_name, -1)
-        if val_examples > 0:
+        if self.dataset_name == "hyperbaton":
+            val_examples = 300
             self.dataset["dev"]["sentence"] = self.dataset["dev"]["sentence"][:val_examples]
             self.dataset["dev"]["label"] = self.dataset["dev"]["label"][:val_examples]
 

--- a/dln/dataset.py
+++ b/dln/dataset.py
@@ -1,3 +1,4 @@
+from abc import abstractmethod
 import json
 import os
 from collections import defaultdict
@@ -5,6 +6,7 @@ from os.path import join as pjoin
 
 import numpy as np
 import yaml
+from datasets import load_dataset as hf_load_dataset
 
 from dln.score import OutputClasses
 from dln.vi.utils import log_message
@@ -40,15 +42,16 @@ def option_shuffle(data_point, rng):
     return new_data_point
 
 
-# accessed outside
+# accessed outside dataset
 # get_size
 # reset_pointer
 # iterate
-# prefix
+# prefix   ????
 # get_data
 # get_batch
 # name
 # instruction
+# output_classes
 
 class Dataset:
     def __init__(
@@ -69,12 +72,14 @@ class Dataset:
         self.dataset_info = self._load_config(
             pjoin(os.path.dirname(os.path.abspath(__file__)), "dataset_info.yaml")
         )
-        self.label_mapping = self.dataset_info[self.dataset_name].get(
-            "label_mapping", {}
-        )
+        self.label_mapping = self.dataset_info.get(
+            self.dataset_name, {}
+        ).get("label_mapping", {})
         self.use_label_mapping = use_label_mapping and self.label_mapping
         self.append_options = append_options
-        self.instruction = self.dataset_info[self.dataset_name]["instruction"]
+        self.instruction = self.dataset_info.get(
+            self.dataset_name, {}
+        ).get("instruction", "")
 
         self.rng = np.random.RandomState(self.random_seed)
         self.few_shot_rng = np.random.RandomState(self.random_seed)
@@ -87,13 +92,22 @@ class Dataset:
             test=dict(sentence=[], label=[]),
         )
         self.load_dataset()
+        self.compute_train_per_class()
+        self.reset()
 
         print("loaded dataset from %s ..." % self.data_path)
         print(
             "we have %s training, %s dev, and %s test data points."
             % (self.train_size, self.dev_size, self.test_size)
         )
-        self.reset()
+
+    @abstractmethod
+    def load_dataset(self):
+        pass
+
+    @property
+    def output_classes(self):
+        return None
 
     @staticmethod
     def _load_config(config_file):
@@ -152,135 +166,7 @@ class Dataset:
             self.dataset[split]["sentence"][i] for i in indices
         ]
 
-    def load_dataset(self):
-        data_shuffling_rng = np.random.RandomState(42)
-
-        if "bbh" in self.data_path:
-            assert self.dataset_name in (
-                "logical_deduction_seven_objects",
-                "hyperbaton",
-                "navigate",
-                "date_understanding",
-            ), self.dataset_name
-            train_valid_file_path = os.path.join(
-                self.data_path.replace("bbh", "bb_minus_bbh"),
-                self.dataset_name + ".json",
-            )
-            with open(train_valid_file_path) as fin:
-                data = json.load(fin)
-                data = data["examples"]
-                train_size = len(data) // 2
-                dev_size = len(data) - train_size
-                train_size = min(
-                    train_size, 1000
-                )  # some dataset has too many data, don't want to have a too large train/valid size
-                dev_size = min(dev_size, 1000)
-                assert train_size > 0, train_size
-                assert dev_size > 0, dev_size
-
-                data_shuffling_rng.shuffle(data)
-                for i in range(len(data)):
-                    if i < train_size:
-                        split = "train"
-                    elif i < train_size + dev_size:
-                        split = "dev"
-                    else:
-                        break
-
-                    # option shuffling in all multiple options cases, skip navigate (yes/no)
-                    if self.dataset_name != "navigate":
-                        data[i] = option_shuffle(data[i], data_shuffling_rng)
-
-                    input, target = data[i]["input"], data[i]["target"]
-
-                    if self.dataset_name == "date_understanding" and split == "train":
-                        # for date understanding, we add training data to dev set, as the dev set is too small
-                        self.dataset["dev"]["sentence"].append(input)
-                        self.dataset["dev"]["label"].append(target)
-                    self.dataset[split]["sentence"].append(input)
-                    self.dataset[split]["label"].append(target)
-
-            test_file_path = os.path.join(self.data_path, self.dataset_name + ".json")
-            with open(test_file_path) as fin:
-                data = json.load(fin)
-                data = data["examples"]
-                for i in range(len(data)):
-                    input, target = data[i]["input"], data[i]["target"]
-                    self.dataset["test"]["sentence"].append(input)
-                    self.dataset["test"]["label"].append(target)
-
-        elif "ordered_prompt" in self.data_path:
-            assert self.dataset_name in ("mpqa", "trec", "subj"), self.dataset_name
-
-            for split in ["train", "dev", "test"]:
-                _split = "dev_subsample" if split == "dev" else split
-                file_path = os.path.join(
-                    self.data_path, self.dataset_name, _split + ".jsonl"
-                )
-                sentence_list, label_list = [], []
-
-                with open(file_path) as fin:
-                    for line in fin:
-                        datapoint = json.loads(line)
-                        sentence, label = datapoint["sentence"], datapoint["label"]
-                        if self.append_options:
-                            sentence = [sentence, "Options:"] + [
-                                "- " + item
-                                for item in list(self.label_mapping.values())
-                            ]
-                            sentence = "\n".join(sentence)
-                        sentence_list.append(sentence)
-                        label_list.append(label)
-
-                if split == "train":
-                    indices = data_shuffling_rng.choice(
-                        len(sentence_list), 1000, replace=False
-                    )
-                    for idx in indices:
-                        self.dataset[split]["sentence"].append(sentence_list[idx])
-                        self.dataset[split]["label"].append(label_list[idx])
-                elif split == "dev":
-                    self.dataset[split]["sentence"] = sentence_list
-                    self.dataset[split]["label"] = label_list
-                elif split == "test":
-                    indices = data_shuffling_rng.choice(
-                        len(sentence_list), 250, replace=False
-                    )
-                    for idx in indices:
-                        self.dataset[split]["sentence"].append(sentence_list[idx])
-                        self.dataset[split]["label"].append(label_list[idx])
-
-        elif "leopard" in self.data_path:
-            assert self.dataset_name in ("disaster", "airline"), self.dataset_name
-            file_path = os.path.join(
-                self.data_path, self.dataset_name, self.dataset_name + "_eval.json"
-            )
-            sentence_list, label_list = [], []
-
-            with open(file_path) as fin:
-                data = json.load(fin)
-                for i in range(len(data)):
-                    sentence, label = data[i]["sentence1"], data[i]["label"]
-                    if self.append_options:
-                        sentence = [sentence, "Options:"] + [
-                            "- " + item for item in list(self.label_mapping.values())
-                        ]
-                        sentence = "\n".join(sentence)
-                    sentence_list.append(sentence)
-                    label_list.append(label)
-            indices = data_shuffling_rng.choice(len(sentence_list), 1500, replace=False)
-            for idx in indices[:1000]:
-                self.dataset["train"]["sentence"].append(sentence_list[idx])
-                self.dataset["train"]["label"].append(label_list[idx])
-            for idx in indices[1000:1250]:
-                self.dataset["dev"]["sentence"].append(sentence_list[idx])
-                self.dataset["dev"]["label"].append(label_list[idx])
-            for idx in indices[1250:]:
-                self.dataset["test"]["sentence"].append(sentence_list[idx])
-                self.dataset["test"]["label"].append(label_list[idx])
-        else:
-            raise NotImplementedError
-
+    def compute_train_per_class(self):
         train_per_class = defaultdict(list)
         for index, label in enumerate(self.dataset["train"]["label"]):
             train_per_class[label].append(index)
@@ -422,61 +308,199 @@ class Dataset:
 
 
 def init_dataset(dataset_id, seed, data_dir, n_few_shots=-1, num_train_examples=-1):
-    ordered_prompt = os.path.join(data_dir, "ordered_prompt")
-    leopard = os.path.join(data_dir, "leopard")
-    bbh = os.path.join(data_dir, "bbh")
-    dataset_location = {
-        "subj": ordered_prompt,
-        "mpqa": ordered_prompt,
-        "trec": ordered_prompt,
-        "disaster": leopard,
-        "airline": leopard,
-        "hyperbaton": bbh,
-        "navigate": bbh,
-        "date_understanding": bbh,
-        "logical_deduction_seven_objects": bbh,
+    datasets = {
+        "subj": OrderedPrompt,
+        "mpqa": OrderedPrompt,
+        "trec": OrderedPrompt,
+        "disaster": Leopard,
+        "airline": Leopard,
+        "hyperbaton": BBH,
+        "navigate": BBH,
+        "date_understanding": BBH,
+        "logical_deduction_seven_objects": BBH,
+        "gsm8k": GSM8K,
     }
+    assert dataset_id in datasets, f"Dataset {dataset_id} not found"
+    dataset_class = datasets[dataset_id]
+    dataset = dataset_class(
+        dataset_path=data_dir,
+        dataset=dataset_id,
+        seed=seed,
+        n_few_shots=n_few_shots,
+        num_train_examples=num_train_examples,
+    )
+    return dataset
 
-    # assert dataset_id in dataset_location, f"Dataset {dataset_id} not found"
-    if dataset_id in dataset_location:
-        dataset = Dataset(
-            dataset_location[dataset_id],
-            dataset_id,
-            seed,
-            n_few_shots=n_few_shots,
-            num_train_examples=num_train_examples,
+
+class BBH(Dataset):
+
+    @property
+    def output_classes(self):
+        if getattr(self, "_output_classes", None) is None:
+            protos = {
+                "hyperbaton": ["a|A", "b|B"],
+                "navigate": ["yes|Yes", "no|No"],
+                "date_understanding": ["a|A", "b|B", "c|C", "d|D", "e|E", "f|F"],
+                "logical_deduction_seven_objects": [
+                    "a|A", "b|B", "c|C", "d|D", "e|E", "f|F", "g|G"
+                ],
+            }.get(self.dataset_name)
+            self._output_classes = OutputClasses(protos=protos)
+        return self._output_classes
+
+    def load_dataset(self):
+        self.data_path = os.path.join(self.data_path, "bb_minus_bbh")
+        data_shuffling_rng = np.random.RandomState(self.random_seed)
+        train_valid_file_path = os.path.join(
+            self.data_path,
+            self.dataset_name + ".json",
         )
-        val_examples = {"hyperbaton": 300}.get(dataset_id, -1)
-        protos = {
-            "hyperbaton": ["a|A", "b|B"],
-            "airline": ["positive|Positive", "negative|Negative", "neutral|Neutral"],
-            "navigate": ["yes|Yes", "no|No"],
-            "date_understanding": ["a|A", "b|B", "c|C", "d|D", "e|E", "f|F"],
-            "logical_deduction_seven_objects": [
-                "a|A",
-                "b|B",
-                "c|C",
-                "d|D",
-                "e|E",
-                "f|F",
-                "g|G",
-            ],
-        }.get(dataset_id, list(dataset.label_mapping.values()))
-        output_classes = OutputClasses(protos=protos)
-    if dataset_id == "gsm8k":
-        dataset = GSM8K(
-            dataset_path=data_dir,
-            dataset=dataset_id,
-            seed=seed,
-            n_few_shots=n_few_shots,
-            num_train_examples=num_train_examples,
+        with open(train_valid_file_path) as fin:
+            data = json.load(fin)
+
+        data = data["examples"]
+        train_size = len(data) // 2
+        dev_size = len(data) - train_size
+        train_size = min(
+            train_size, 1000
+        )  # some dataset has too many data, don't want to have a too large train/valid size
+        dev_size = min(dev_size, 1000)
+        assert train_size > 0, train_size
+        assert dev_size > 0, dev_size
+
+        data_shuffling_rng.shuffle(data)
+        for i in range(len(data)):
+            if i < train_size:
+                split = "train"
+            elif i < train_size + dev_size:
+                split = "dev"
+            else:
+                break
+
+            # option shuffling in all multiple options cases, skip navigate (yes/no)
+            if self.dataset_name != "navigate":
+                data[i] = option_shuffle(data[i], data_shuffling_rng)
+
+            input, target = data[i]["input"], data[i]["target"]
+
+            if self.dataset_name == "date_understanding" and split == "train":
+                # for date understanding, we add training data to dev set, as the dev set is too small
+                self.dataset["dev"]["sentence"].append(input)
+                self.dataset["dev"]["label"].append(target)
+            self.dataset[split]["sentence"].append(input)
+            self.dataset[split]["label"].append(target)
+
+        test_file_path = os.path.join(self.data_path, self.dataset_name + ".json")
+        with open(test_file_path) as fin:
+            data = json.load(fin)
+            data = data["examples"]
+            for i in range(len(data)):
+                input, target = data[i]["input"], data[i]["target"]
+                self.dataset["test"]["sentence"].append(input)
+                self.dataset["test"]["label"].append(target)
+
+        # TODO: use a parameter instead
+        val_examples = {"hyperbaton": 300}.get(self.dataset_name, -1)
+        if val_examples > 0:
+            self.dataset["dev"]["sentence"] = self.dataset["dev"]["sentence"][:val_examples]
+            self.dataset["dev"]["label"] = self.dataset["dev"]["label"][:val_examples]
+
+
+class Leopard(Dataset):
+
+    @property
+    def output_classes(self):
+        if getattr(self, "_output_classes", None) is None:
+            protos = {
+                "airline": ["positive|Positive", "negative|Negative", "neutral|Neutral"],
+            }.get(self.dataset_name, list(self.label_mapping.values()))
+            self._output_classes = OutputClasses(protos=protos)
+        return self._output_classes
+
+    def load_dataset(self):
+        self.data_path = os.path.join(self.data_path, "leopard")
+        data_shuffling_rng = np.random.RandomState(self.random_seed)
+        assert self.dataset_name in ("disaster", "airline"), self.dataset_name
+        file_path = os.path.join(
+            self.data_path, self.dataset_name, self.dataset_name + "_eval.json"
         )
-        val_examples = -1
-        output_classes = None
-    return dataset, output_classes, val_examples
+        sentence_list, label_list = [], []
+
+        with open(file_path) as fin:
+            data = json.load(fin)
+            for i in range(len(data)):
+                sentence, label = data[i]["sentence1"], data[i]["label"]
+                if self.append_options:
+                    sentence = [sentence, "Options:"] + [
+                        "- " + item for item in list(self.label_mapping.values())
+                    ]
+                    sentence = "\n".join(sentence)
+                sentence_list.append(sentence)
+                label_list.append(label)
+        indices = data_shuffling_rng.choice(len(sentence_list), 1500, replace=False)
+        for idx in indices[:1000]:
+            self.dataset["train"]["sentence"].append(sentence_list[idx])
+            self.dataset["train"]["label"].append(label_list[idx])
+        for idx in indices[1000:1250]:
+            self.dataset["dev"]["sentence"].append(sentence_list[idx])
+            self.dataset["dev"]["label"].append(label_list[idx])
+        for idx in indices[1250:]:
+            self.dataset["test"]["sentence"].append(sentence_list[idx])
+            self.dataset["test"]["label"].append(label_list[idx])
 
 
-from datasets import load_dataset, get_dataset_split_names
+class OrderedPrompt(Dataset):
+
+    @property
+    def output_classes(self):
+        if getattr(self, "_output_classes", None) is None:
+            self._output_classes = OutputClasses(
+                protos=list(self.label_mapping.values())
+            )
+        return self._output_classes
+
+    def load_dataset(self):
+        self.data_path = os.path.join(self.data_path, "ordered_prompt")
+        data_shuffling_rng = np.random.RandomState(self.random_seed)
+        assert self.dataset_name in ("mpqa", "trec", "subj"), self.dataset_name
+
+        for split in ["train", "dev", "test"]:
+            _split = "dev_subsample" if split == "dev" else split
+            file_path = os.path.join(
+                self.data_path, self.dataset_name, _split + ".jsonl"
+            )
+            sentence_list, label_list = [], []
+
+            with open(file_path) as fin:
+                for line in fin:
+                    datapoint = json.loads(line)
+                    sentence, label = datapoint["sentence"], datapoint["label"]
+                    if self.append_options:
+                        sentence = [sentence, "Options:"] + [
+                            "- " + item
+                            for item in list(self.label_mapping.values())
+                        ]
+                        sentence = "\n".join(sentence)
+                    sentence_list.append(sentence)
+                    label_list.append(label)
+
+            if split == "train":
+                indices = data_shuffling_rng.choice(
+                    len(sentence_list), 1000, replace=False
+                )
+                for idx in indices:
+                    self.dataset[split]["sentence"].append(sentence_list[idx])
+                    self.dataset[split]["label"].append(label_list[idx])
+            elif split == "dev":
+                self.dataset[split]["sentence"] = sentence_list
+                self.dataset[split]["label"] = label_list
+            elif split == "test":
+                indices = data_shuffling_rng.choice(
+                    len(sentence_list), 250, replace=False
+                )
+                for idx in indices:
+                    self.dataset[split]["sentence"].append(sentence_list[idx])
+                    self.dataset[split]["label"].append(label_list[idx])
 
 
 class GSM8K(Dataset):
@@ -485,31 +509,24 @@ class GSM8K(Dataset):
         self,
         dataset_path,
         dataset,
-        seed=42,
-        use_label_mapping=False,  # not used for non-classification
-        append_options=False,  # not used for non-classification
+        seed,
+        use_label_mapping=False,
+        append_options=False,
         n_few_shots=-1,
         num_train_examples=-1,
-        instruction: str = "",
     ):
-        self.data_path = dataset_path or "../../data/huggingface/datasets"
-        self.dataset_name = dataset
-        self.random_seed = seed
-        self.use_label_mapping = use_label_mapping
-        self.append_options = append_options
-        self.n_few_shots = n_few_shots
-        self.num_train_examples = num_train_examples
-        self.instruction = instruction
+        if use_label_mapping or append_options:
+            log_message("GSM8K does not support label mapping or append opptions.")
 
-        self.rng = np.random.RandomState(self.random_seed)  # move to baseclass
-        self.few_shot_rng = np.random.RandomState(self.random_seed)  # move to baseclass
-
-        self.dataset = self.load_dataset(
-            dataset_name=self.dataset_name,
-            config_name='main',
-            cache_dir=self.data_path,
+        super().__init__(
+            dataset_path=dataset_path,
+            dataset=dataset,
+            seed=seed,
+            use_label_mapping=False,
+            append_options=False,
+            n_few_shots=n_few_shots,
+            num_train_examples=num_train_examples,
         )
-        self.reset()
 
     @staticmethod
     def _split_answer(answers):
@@ -521,29 +538,21 @@ class GSM8K(Dataset):
             final_answers.append(a)
         return steps, final_answers
 
-    def load_dataset(self, dataset_name, config_name, cache_dir):
-        hf_dataset = load_dataset(
-            dataset_name, config_name, cache_dir=cache_dir
+    def load_dataset(self):
+        self.data_path = os.path.join(self.data_path, "huggingface/datasets")
+        hf_dataset = hf_load_dataset(
+            self.dataset_name, 'main', cache_dir=self.data_path
         ).shuffle(seed=self.random_seed)
-        
-        dataset = dict(
-            train_per_class=dict(),
-            train=dict(sentence=[], label=[]),
-            dev=dict(sentence=[], label=[]),
-            test=dict(sentence=[], label=[]),
-        )
 
         train_size = hf_dataset["train"].num_rows // 2
         train_dataset = hf_dataset["train"][:train_size]
         dev_dataset = hf_dataset["train"][train_size:]
         test_dataset = hf_dataset['test']
 
-        dataset["train"]["sentence"] = train_dataset['question']
-        dataset["train"]["label"] = self._split_answer(train_dataset['answer'])[1]
-        dataset["dev"]["sentence"] = dev_dataset['question']
-        dataset["dev"]["label"] = self._split_answer(dev_dataset['answer'])[1]
+        self.dataset["train"]["sentence"] = train_dataset['question']
+        self.dataset["train"]["label"] = self._split_answer(train_dataset['answer'])[1]
+        self.dataset["dev"]["sentence"] = dev_dataset['question']
+        self.dataset["dev"]["label"] = self._split_answer(dev_dataset['answer'])[1]
 
-        dataset["test"]["sentence"] = test_dataset['question']
-        dataset["test"]["label"] = self._split_answer(test_dataset['answer'])[1]
-
-        return dataset
+        self.dataset["test"]["sentence"] = test_dataset['question']
+        self.dataset["test"]["label"] = self._split_answer(test_dataset['answer'])[1]

--- a/dln/dataset_info.yaml
+++ b/dln/dataset_info.yaml
@@ -48,6 +48,7 @@ date_understanding:
   prefix: "Infer the date from context."
   instruction: "Infer the date from context."
   output_type: "single word"
+  protos: ["a|A", "b|B", "c|C", "d|D", "e|E", "f|F"]
 
 hyperbaton:
   # output space: ["(A)", "(B)"]
@@ -57,6 +58,7 @@ hyperbaton:
   prefix: "Which sentence has the correct adjective order:\n"
   instruction: "Which sentence has the correct adjective order:"
   output_type: "single word"
+  protos: ["a|A", "b|B"]
 
 logical_deduction_seven_objects:
   # output space: ["(A)", "(B)", "(C)", "(D)", "(E)", "(F)", "(G)"]
@@ -66,6 +68,7 @@ logical_deduction_seven_objects:
   prefix: "The following paragraphs each describe a set of seven objects arranged in a fixed order. The statements are logically consistent within each paragraph."
   instruction: "A seven-object logical deduction task which requires deducing the order of a sequence of objects."
   output_type: "single word"
+  protos: ["a|A", "b|B", "c|C", "d|D", "e|E", "f|F", "g|G"]
 
 navigate:
   # output space: ["Yes", "No"]
@@ -75,6 +78,7 @@ navigate:
   prefix: "If you follow these instructions, do you return to the starting point?"
   instruction: "Read the following sentence, then determine whether you return to the starting point."
   output_type: "single word"
+  protos: ["yes|Yes", "no|No"]
 
 ###
 # From Leopard
@@ -103,3 +107,4 @@ airline:
   label_mapping: {'positive': 'positive', 'negative': 'negative', 'neutral': 'neutral'}
   instruction: "Read the following sentence, then choose whether it is positive, negative, or neutral."
   output_type: "single word"
+  protos: ["positive|Positive", "negative|Negative", "neutral|Neutral"]

--- a/dln/vi/utils.py
+++ b/dln/vi/utils.py
@@ -69,15 +69,15 @@ class ResultLogEntry():
 
 
 class ResultLogWriter(object):
-    def __init__(self, dataset: str, path: str, name: str = None):
+    def __init__(self, name: str, path: str):
         """
         Args:
-            dataset: The name of the dataset (used as name if save_name is None)
-            save_name: Dictionary key to save the results under
+            name: File name
+            path: File location
         Returns:
             A ResultLogWriter object
         """
-        self.name = name if name is not None else dataset.dataset_name
+        self.name = name
         self.path = path
         self.result_dict = {}
         self.result_dict[self.name] = {'training': [], 'examples': []}

--- a/projects/vi_dln/scripts/two_layers_e2e/date_understanding.sh
+++ b/projects/vi_dln/scripts/two_layers_e2e/date_understanding.sh
@@ -45,6 +45,5 @@ for seed in 13 42 25; do
         --forward_use_classes True \
         --logp_penalty ${logp_penalty} \
         --posterior_temp ${posterior_temp} \
-        --strip_options_for_hidden True \
-        --strip_prefix_for_hidden False
+        --strip_options_for_hidden True
 done

--- a/projects/vi_dln/scripts/two_layers_e2e/logical_deduction_seven_objects.sh
+++ b/projects/vi_dln/scripts/two_layers_e2e/logical_deduction_seven_objects.sh
@@ -48,7 +48,6 @@ for seed in 13 42 25; do
         --logp_penalty ${logp_penalty} \
         --posterior_temp ${posterior_temp} \
         --strip_options_for_hidden True \
-        --strip_prefix_for_hidden False \
         --fwd_max_tokens ${fwd_max_tokens} \
         --bwd_max_tokens ${bwd_max_tokens}
 done

--- a/projects/vi_dln/scripts/two_layers_e2e/navigate.sh
+++ b/projects/vi_dln/scripts/two_layers_e2e/navigate.sh
@@ -43,6 +43,5 @@ for seed in 13 42 25; do
         --forward_use_classes True \
         --logp_penalty ${logp_penalty} \
         --posterior_temp ${posterior_temp} \
-        --strip_options_for_hidden True \
-        --strip_prefix_for_hidden False
+        --strip_options_for_hidden True
 done

--- a/projects/vi_dln/vi_main.py
+++ b/projects/vi_dln/vi_main.py
@@ -431,7 +431,7 @@ def main(
     dataset, output_classes, val_examples = init_dataset(dataset, seed, data_dir, n_shots, num_train_examples)
     if result_data_path is None:
         result_data_path = os.path.join(out_dir, "result_data.log")
-    result_writer = ResultLogWriter(dataset, path=result_data_path, name=result_exp_name)
+    result_writer = ResultLogWriter(dataset.dataset_name, path=result_data_path)
 
     init_p1, init_p2 = init_prompts(dataset, init_p1, init_p2)
     if wandb_enabled:

--- a/projects/vi_dln/vi_main.py
+++ b/projects/vi_dln/vi_main.py
@@ -175,12 +175,6 @@ def test(dataset, model, loss_fn, iteration, writer, cost_only=False):
     help="Remove options from examples for the hidden layer.",
 )
 @click.option(
-    "--strip_prefix_for_hidden",
-    type=bool,
-    default=False,
-    help="Strip the prefix from the examples if it exists in some tasks, e.g. BBH.",
-)
-@click.option(
     "--trust_factor",
     default=0.0,
     help="Trust-region factor for prompt update. Ensures KL divergence between the old and new prompt is small.",
@@ -369,7 +363,6 @@ def main(
     num_p_samples,
     num_h_samples,
     strip_options_for_hidden,
-    strip_prefix_for_hidden,
     trust_factor,
     use_memory,
     init_p1,
@@ -481,7 +474,6 @@ def main(
         p1_max_tokens=p1_max_tokens,
         p2_max_tokens=p2_max_tokens,
         posterior_temp=posterior_temp,
-        strip_prefix_for_hidden=dataset.prefix if strip_prefix_for_hidden else None,
         output_scoring_function=output_scoring_function,
         hidden_scoring_function=hidden_scoring_function,
         num_p1_steps=num_p1_steps,

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ numpy
 requests==2.31.0
 pyyaml
 transformers
+datasets

--- a/tests/test_dln_dataset.py
+++ b/tests/test_dln_dataset.py
@@ -8,37 +8,37 @@ from dln.dataset import Dataset, init_dataset, option_shuffle
 
 def test_init_dataset_subj():
     with patch.object(Dataset, "load_dataset", MagicMock):
-        dataset, output_classes, val_examples = init_dataset("subj", 42, "./data")
+        dataset = init_dataset("subj", 42, "./data")
     assert (
         dataset.instruction
         == "Read the following sentence, then choose whether it is subjective or objective."
     )
     assert dataset.dataset_name == "subj"
-    assert output_classes.protos == ["subjective", "objective"]
-    assert val_examples == -1
+    assert dataset.output_classes.protos == ["subjective", "objective"]
+    assert dataset.dev_size == 256
 
 
 def test_init_dataset_mpqa():
     with patch.object(Dataset, "load_dataset", MagicMock):
-        dataset, output_classes, val_examples = init_dataset("mpqa", 42, "./data")
+        dataset = init_dataset("mpqa", 42, "./data")
     assert (
         dataset.instruction
         == "Read the following review, then choose whether it is negative or positive."
     )
     assert dataset.dataset_name == "mpqa"
-    assert output_classes.protos == ["negative", "positive"]
-    assert val_examples == -1
+    assert dataset.output_classes.protos == ["negative", "positive"]
+    assert dataset.dev_size == 256
 
 
 def test_init_dataset_trec():
     with patch.object(Dataset, "load_dataset", MagicMock):
-        dataset, output_classes, val_examples = init_dataset("trec", 42, "./data")
+        dataset = init_dataset("trec", 42, "./data")
     assert (
         dataset.instruction
         == "Read the following question, then choose whether it is about a description, entity, expression, human, location or number."
     )
     assert dataset.dataset_name == "trec"
-    assert output_classes.protos == [
+    assert dataset.output_classes.protos == [
         "description",
         "entity",
         "expression",
@@ -46,68 +46,68 @@ def test_init_dataset_trec():
         "location",
         "number",
     ]
-    assert val_examples == -1
+    assert dataset.dev_size == 256
 
 
 def test_init_dataset_disaster():
     with patch.object(Dataset, "load_dataset", MagicMock):
-        dataset, output_classes, val_examples = init_dataset("disaster", 42, "./data")
+        dataset = init_dataset("disaster", 42, "./data")
     assert (
         dataset.instruction
         == "Read the following sentence, then choose whether it is relevant to a disaster."
     )
     assert dataset.dataset_name == "disaster"
-    assert output_classes.protos == ["no", "yes"]
-    assert val_examples == -1
+    assert dataset.output_classes.protos == ["no", "yes"]
+    assert dataset.dev_size == 250
 
 
 def test_init_dataset_airline():
     with patch.object(Dataset, "load_dataset", MagicMock):
-        dataset, output_classes, val_examples = init_dataset("airline", 42, "./data")
+        dataset = init_dataset("airline", 42, "./data")
     assert (
         dataset.instruction
         == "Read the following sentence, then choose whether it is positive, negative, or neutral."
     )
     assert dataset.dataset_name == "airline"
-    assert output_classes.protos == ["positive|Positive", "negative|Negative", "neutral|Neutral"]
-    assert val_examples == -1
+    assert dataset.output_classes.protos == ["positive|Positive", "negative|Negative", "neutral|Neutral"]
+    assert dataset.dev_size == 250
 
 
 def test_init_dataset_hyperbaton():
     with patch.object(Dataset, "load_dataset", MagicMock):
-        dataset, output_classes, val_examples = init_dataset("hyperbaton", 42, "./data")
+        dataset = init_dataset("hyperbaton", 42, "./data")
     assert dataset.instruction == "Which sentence has the correct adjective order:"
     assert dataset.dataset_name == "hyperbaton"
-    assert output_classes.protos == ["a|A", "b|B"]
-    assert val_examples == 300
+    assert dataset.output_classes.protos == ["a|A", "b|B"]
+    assert dataset.dev_size == 300
 
 
 def test_init_dataset_navigate():
     with patch.object(Dataset, "load_dataset", MagicMock):
-        dataset, output_classes, val_examples = init_dataset("navigate", 42, "./data")
+        dataset = init_dataset("navigate", 42, "./data")
     assert (
         dataset.instruction
         == "Read the following sentence, then determine whether you return to the starting point."
     )
     assert dataset.dataset_name == "navigate"
-    assert output_classes.protos == ["yes|Yes", "no|No"]
-    assert val_examples == -1
+    assert dataset.output_classes.protos == ["yes|Yes", "no|No"]
+    assert dataset.dev_size == 375
 
 
 def test_init_dataset_date_understanding():
     with patch.object(Dataset, "load_dataset", MagicMock):
-        dataset, output_classes, val_examples = init_dataset(
+        dataset = init_dataset(
             "date_understanding", 42, "./data"
         )
     assert dataset.instruction == "Infer the date from context."
     assert dataset.dataset_name == "date_understanding"
-    assert output_classes.protos == ["a|A", "b|B", "c|C", "d|D", "e|E", "f|F"]
-    assert val_examples == -1
+    assert dataset.output_classes.protos == ["a|A", "b|B", "c|C", "d|D", "e|E", "f|F"]
+    assert dataset.dev_size == 119
 
 
 def test_init_dataset_logical_deduction_seven_objects():
     with patch.object(Dataset, "load_dataset", MagicMock):
-        dataset, output_classes, val_examples = init_dataset(
+        dataset = init_dataset(
             "logical_deduction_seven_objects", 42, "./data"
         )
     assert (
@@ -115,8 +115,8 @@ def test_init_dataset_logical_deduction_seven_objects():
         == "A seven-object logical deduction task which requires deducing the order of a sequence of objects."
     )
     assert dataset.dataset_name == "logical_deduction_seven_objects"
-    assert output_classes.protos == ["a|A", "b|B", "c|C", "d|D", "e|E", "f|F", "g|G"]
-    assert val_examples == -1
+    assert dataset.output_classes.protos == ["a|A", "b|B", "c|C", "d|D", "e|E", "f|F", "g|G"]
+    assert dataset.dev_size == 225
 
 
 def test_init_dataset_not_found():

--- a/tests/test_vi_model.py
+++ b/tests/test_vi_model.py
@@ -397,15 +397,3 @@ def test_strip_options(loss_fn):
     expected_output = np.array(["This is a test", "No options here", "Another test"])
     output_data = model.strip_options(input_data)
     assert np.array_equal(output_data, expected_output)
-
-
-def test_strip_prefix(loss_fn):
-    model = VILModel(
-        loss_fn, strip_prefix_for_hidden="PREFIX:"
-    )
-    input_data = np.array(
-        ["PREFIX: This is a test", "No prefix here", "PREFIX: Another test"]
-    )
-    expected_output = np.array(["This is a test", "No prefix here", "Another test"])
-    output_data = model.strip_prefix(input_data)
-    assert np.array_equal(output_data, expected_output)


### PR DESCRIPTION
This PR includes:
- Add GSM8K dataset
- Split BBH, Leopard, and OrderedPrompt into their own classes.
  - load_dataset remains the same, I just moved the logic to their respective classes.
  - Dataset now only contains logic related to the splits/iterate/batch.
- Move protos to dataset_info.yaml
- Remove unused strip_prefix_for_hidden