### PR TITLE
Seed LLM generate

### DIFF
--- a/projects/vi_dln/vi_main.py
+++ b/projects/vi_dln/vi_main.py
@@ -145,13 +145,13 @@ def test(dataset, model, loss_fn, iteration, writer, cost_only=False):
 
 
 @click.command()
-@click.option("--seed", default=42, help="Random seed.")
+@click.option("--seed", type=int, default=42, help="Random seed.")
 @click.option("--out_dir", default="log/")
 @click.option("--data_dir", default="../../data")
 @click.option("--max_train_size", default=-1, type=int, help="Use only so many train examples.")
 @click.option("--max_dev_size", default=-1, type=int, help="Use only so many dev examples.")
 @click.option("--max_test_size", default=-1, type=int, help="Use only so many test examples.")
-@click.option("--val_freq", default=2)
+@click.option("--val_freq", type=int, default=2)
 @click.option("--do_first_eval", is_flag=True)
 @click.option("--do_zero_shot", is_flag=True)
 @click.option("--n_shots", default=-1, type=int)
@@ -178,16 +178,19 @@ def test(dataset, model, loss_fn, iteration, writer, cost_only=False):
 )
 @click.option(
     "--trust_factor",
+    type=float,
     default=0.0,
     help="Trust-region factor for prompt update. Ensures KL divergence between the old and new prompt is small.",
 )
 @click.option(
     "--fwd_temp",
+    type=float,
     default=0.0,
     help="Forward temperature",
 )
 @click.option(
     "--bwd_temp",
+    type=float,
     default=0.7,
     help="Backward temperature",
 )

--- a/projects/vi_dln/vi_main.py
+++ b/projects/vi_dln/vi_main.py
@@ -443,13 +443,13 @@ def main(
     bwd_model_type = bwd_model_type or fwd_model_type
 
     llm_registry = LLMRegistry()
-
     fwd_model = llm_registry.register(
         "fwd_model",
         fwd_model_type,
         temperature=0.0,
         max_tokens=fwd_max_tokens,
         stop=None,
+        seed=seed,
     )
 
     bwd_model = llm_registry.register(
@@ -458,6 +458,7 @@ def main(
         temperature=bwd_temp,
         max_tokens=bwd_max_tokens,
         stop=None,
+        seed=seed,
     )
 
     postproc = None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ def mock_llm_func():
                     self.encoder = instantiate_tokenizer(model_name)
                 super().__init__(model_name)
 
-            def generate(self, inputs, **kwargs):
+            def _generate(self, inputs, **kwargs):
                 return inputs
 
             def encode(self, string):

--- a/tests/test_dln_operator.py
+++ b/tests/test_dln_operator.py
@@ -60,7 +60,7 @@ def test_get_completion_response(mock_openai_api):
 def test_generate(mock_openai_api, async_generation):
     gpt = GPT("text-davinci-003")
     prompt = "What is the largest city in Quebec?"
-    response = gpt.generate(
+    response = gpt._generate(
         inputs=[prompt, prompt],
         batch_size=1,
         async_generation=async_generation,
@@ -71,7 +71,7 @@ def test_generate(mock_openai_api, async_generation):
 def test_generate_seeds():
 
     class MockGPT(LLM):
-        def generate(self, inputs, **kwargs):
+        def _generate(self, inputs, **kwargs):
             return kwargs
         def encode(self, string):
             return string
@@ -122,7 +122,7 @@ def test_openai_invalid_request_error(monkeypatch):
     gpt = GPT("text-davinci-003")
     prompt = "What is the largest city in Quebec?"
     with pytest.raises(openai.InvalidRequestError, match="Invalid request"):
-        gpt.generate(prompt)
+        gpt._generate(prompt)
 
 
 @pytest.fixture

--- a/tests/test_dln_operator.py
+++ b/tests/test_dln_operator.py
@@ -78,6 +78,9 @@ def test_generate_seeds():
         def has_logprobs(self):
             return True
 
+        def clean_text(self, text):
+            return text
+
     prompt = "Prompt test"
 
     # generate seed from random state

--- a/tests/test_dln_score.py
+++ b/tests/test_dln_score.py
@@ -5,7 +5,7 @@ from dln.score import LogProbsScore, OutputClasses
 
 def test_logprobs_score_with_output_classes(score_requests, top_logprobs, mock_llm_func):
     mock_llm = mock_llm_func("text-davinci-003")
-    mock_llm.generate = top_logprobs
+    mock_llm._generate = top_logprobs
     logprobs_score = LogProbsScore(mock_llm)
 
     logprobs = logprobs_score.score_requests(
@@ -24,9 +24,9 @@ def test_logprobs_score_with_output_classes(score_requests, top_logprobs, mock_l
 
 def test_logprobs_score_without_output_classes(score_requests, raw_logprobs, mock_llm_func):
     mock_llm = mock_llm_func("text-davinci-003")
-    mock_llm.generate = raw_logprobs
+    mock_llm._generate = raw_logprobs
     logprobs_score = LogProbsScore(mock_llm)
-    
+
     logprobs = logprobs_score.score_requests(score_requests)
 
     np.testing.assert_almost_equal(logprobs.logp_targets, [-0.7682657, -0.7632834])

--- a/tests/test_vi_layers.py
+++ b/tests/test_vi_layers.py
@@ -45,7 +45,7 @@ def test_apply_residual_with_template(mock_logprobs_score, mock_llm):
 
 
 def test_log_p_with_output_classes(top_logprobs, mock_logprobs_score, mock_llm):
-    mock_logprobs_score.forward_evaluate.generate = top_logprobs
+    mock_logprobs_score.forward_evaluate._generate = top_logprobs
     inputs = ["1 + 1", "1 * 1"]
     outputs = ["B", "A"]
     output_classes = OutputClasses(protos=["a|A", "b|B"])
@@ -69,7 +69,7 @@ def test_log_p_with_output_classes(top_logprobs, mock_logprobs_score, mock_llm):
 
 
 def test_log_p_without_output_classes(raw_logprobs, score_requests, mock_logprobs_score, mock_llm):
-    mock_logprobs_score.forward_evaluate.generate = raw_logprobs
+    mock_logprobs_score.forward_evaluate._generate = raw_logprobs
     inputs = [s.context for s in score_requests]
     outputs = ["B", "A"]
     prior_layer = PriorLayer(
@@ -83,7 +83,7 @@ def test_log_p_without_output_classes(raw_logprobs, score_requests, mock_logprob
 
 
 def test_forward_with_output_class(top_logprobs, mock_logprobs_score, mock_llm):
-    mock_logprobs_score.forward_evaluate.generate = top_logprobs
+    mock_logprobs_score.forward_evaluate._generate = top_logprobs
     inputs = ["1 + 1", "1 * 1"]
     output_classes = OutputClasses(protos=["A|a", "B|b"])
     prior_layer = PriorLayer(
@@ -97,7 +97,7 @@ def test_forward_with_output_class(top_logprobs, mock_logprobs_score, mock_llm):
 
 
 def test_forward_without_output_class(text_outputs, mock_logprobs_score, mock_llm):
-    mock_llm.generate = text_outputs
+    mock_llm._generate = text_outputs
     inputs = ["1 + 1", "1 * 1"]
     prior_layer = PriorLayer(
         logprobs_score=mock_logprobs_score,
@@ -111,7 +111,7 @@ def test_forward_without_output_class(text_outputs, mock_logprobs_score, mock_ll
 
 def test_forward_strip_double_newlines(mock_logprobs_score, mock_llm):
     text_output = lambda *args, **kwargs: ["A\n\n"]
-    mock_llm.generate = text_output
+    mock_llm._generate = text_output
     inputs = ["1 + 1"]
     prior_layer = PriorLayer(
         logprobs_score=mock_logprobs_score,


### PR DESCRIPTION
Generate a random seed for every request if the LLM was initialized with a seed.
Seeds provided when `LLM.generate(prompt, seed)` is called has priority over the internal seed.

Seed per request support varies by model. As of today, only `gpt-3.5-turbo-instruct` supports it. `gpt-4-turbo` supports it to some extension. Other models such as gpt-3, gpt-4, and VLLM models (phi-2, llama2, etc) ignore the seed.