### PR TITLE
Upgrade actions to use Node.js 20

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL


### PR DESCRIPTION
Fixes CodeQL warning:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3.

Actions/checkout v4 uses node20 by default.